### PR TITLE
Fixed bind mounts and absolute destination paths

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -86,3 +86,13 @@ func RunCommand(args ...string) error {
 	}
 	return nil
 }
+
+func StringInList(list []string, str string) bool {
+	for idx := range(list) {
+		if list[idx] == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Bind mounts in lxc require that the destination directory be present inside the container or the create=dir option be passed.
Destination paths in lxc.mount.entry are required to be relative