### PR TITLE
Fix race, update API and container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV K8S_URL="https://dl.k8s.io/v1.20.6/kubernetes-server-linux-amd64.tar.gz"
 
 ## development
 ENV LXC_GIT_REPO=https://github.com/lxc/lxc.git
-ENV LXC_GIT_VERSION=master
+ENV LXC_GIT_VERSION=b9f3cd48ecfed02e4218b55ea1b46273e429a083
 
 ENV LXCRI_GIT_REPO=https://github.com/lxc/lxcri.git
 ENV LXCRI_GIT_VERSION=main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ARG installcmd=install_all
 
 #ENV PKGS="psmisc util-linux"
 
-ENV GOLANG_SRC=https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
-ENV GOLANG_CHECKSUM=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
+ENV GOLANG_SRC=https://golang.org/dl/go1.16.3.linux-amd64.tar.gz
+ENV GOLANG_CHECKSUM=951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
 
 ENV CNI_PLUGINS_GIT_REPO=https://github.com/containernetworking/plugins.git
 ENV CNI_PLUGINS_GIT_VERSION=v0.9.1
@@ -13,14 +13,14 @@ ENV CONMON_GIT_REPO=https://github.com/containers/conmon.git
 ENV CONMON_GIT_VERSION=v2.0.27
 
 ENV CRIO_GIT_REPO=https://github.com/cri-o/cri-o.git
-ENV CRIO_GIT_VERSION=v1.20.1
+ENV CRIO_GIT_VERSION=v1.20.2
 
 ENV CRICTL_CHECKSUM=44d5f550ef3f41f9b53155906e0229ffdbee4b19452b4df540265e29572b899c
 ENV CRICTL_URL="https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz"
 
 # see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
-ENV K8S_CHECKSUM=37738bc8430b0832f32c6d13cdd68c376417270568cd9b31a1ff37e96cfebcc1e2970c72bed588f626e35ed8273671c77200f0d164e67809b5626a2a99e3c5f5
-ENV K8S_URL="https://dl.k8s.io/v1.20.4/kubernetes-server-linux-amd64.tar.gz"
+ENV K8S_CHECKSUM=ac936e05aef7bb887a5fb57d50f8c384ee395b5f34c85e5c0effd8709db042359f63247d4a6ae2c0831fe019cd3029465377117e42fff1b00a8e4b7473b88db9
+ENV K8S_URL="https://dl.k8s.io/v1.20.6/kubernetes-server-linux-amd64.tar.gz"
 
 ## development
 ENV LXC_GIT_REPO=https://github.com/lxc/lxc.git

--- a/cgroup.go
+++ b/cgroup.go
@@ -97,7 +97,7 @@ func configureCgroup(rt *Runtime, c *Container) error {
 	}
 
 	if pids := c.Spec.Linux.Resources.Pids; pids != nil {
-		if err := c.SetConfigItem("lxc.cgroup2.pids.max", fmt.Sprintf("%d", pids.Limit)); err != nil {
+		if err := c.setConfigItem("lxc.cgroup2.pids.max", fmt.Sprintf("%d", pids.Limit)); err != nil {
 			return err
 		}
 	}
@@ -122,30 +122,30 @@ func configureCgroupPath(rt *Runtime, c *Container) error {
 		c.CgroupDir = c.Spec.Linux.CgroupsPath
 	}
 
-	if err := c.SetConfigItem("lxc.cgroup.relative", "0"); err != nil {
+	if err := c.setConfigItem("lxc.cgroup.relative", "0"); err != nil {
 		return err
 	}
 
 	// @since lxc @a900cbaf257c6a7ee9aa73b09c6d3397581d38fb
 	// checking for on of the config items shuld be enough, because they were introduced together ...
 	//  lxc.cgroup.dir.payload and lxc.cgroup.dir.monitor
-	splitCgroup := c.SupportsConfigItem("lxc.cgroup.dir.container", "lxc.cgroup.dir.monitor")
+	splitCgroup := c.supportsConfigItem("lxc.cgroup.dir.container", "lxc.cgroup.dir.monitor")
 
 	if !splitCgroup || rt.MonitorCgroup == "" {
-		return c.SetConfigItem("lxc.cgroup.dir", c.CgroupDir)
+		return c.setConfigItem("lxc.cgroup.dir", c.CgroupDir)
 	}
 
 	c.MonitorCgroupDir = filepath.Join(rt.MonitorCgroup, c.ContainerID+".scope")
 
-	if err := c.SetConfigItem("lxc.cgroup.dir.container", c.CgroupDir); err != nil {
+	if err := c.setConfigItem("lxc.cgroup.dir.container", c.CgroupDir); err != nil {
 		return err
 	}
-	if err := c.SetConfigItem("lxc.cgroup.dir.monitor", c.MonitorCgroupDir); err != nil {
+	if err := c.setConfigItem("lxc.cgroup.dir.monitor", c.MonitorCgroupDir); err != nil {
 		return err
 	}
 
-	if c.SupportsConfigItem("lxc.cgroup.dir.monitor.pivot") {
-		if err := c.SetConfigItem("lxc.cgroup.dir.monitor.pivot", rt.MonitorCgroup); err != nil {
+	if c.supportsConfigItem("lxc.cgroup.dir.monitor.pivot") {
+		if err := c.setConfigItem("lxc.cgroup.dir.monitor.pivot", rt.MonitorCgroup); err != nil {
 			return err
 		}
 	}
@@ -191,16 +191,16 @@ func configureDeviceController(c *Container) error {
 			}
 			// decompose
 			val := fmt.Sprintf("%s %s:%s %s", blockDevice, maj, min, dev.Access)
-			if err := c.SetConfigItem(key, val); err != nil {
+			if err := c.setConfigItem(key, val); err != nil {
 				return err
 			}
 			val = fmt.Sprintf("%s %s:%s %s", charDevice, maj, min, dev.Access)
-			if err := c.SetConfigItem(key, val); err != nil {
+			if err := c.setConfigItem(key, val); err != nil {
 				return err
 			}
 		case blockDevice, charDevice:
 			val := fmt.Sprintf("%s %s:%s %s", dev.Type, maj, min, dev.Access)
-			if err := c.SetConfigItem(key, val); err != nil {
+			if err := c.setConfigItem(key, val); err != nil {
 				return err
 			}
 		default:
@@ -216,32 +216,32 @@ func configureCPUController(clxc *Runtime, slinux *specs.LinuxCPU) error {
 	clxc.Log.Debug().Msg("TODO configure cgroup cpu controller")
 	/*
 		if cpu.Shares != nil && *cpu.Shares > 0 {
-				if err := clxc.SetConfigItem("lxc.cgroup2.cpu.shares", fmt.Sprintf("%d", *cpu.Shares)); err != nil {
+				if err := clxc.setConfigItem("lxc.cgroup2.cpu.shares", fmt.Sprintf("%d", *cpu.Shares)); err != nil {
 					return err
 				}
 		}
 		if cpu.Quota != nil && *cpu.Quota > 0 {
-			if err := clxc.SetConfigItem("lxc.cgroup2.cpu.cfs_quota_us", fmt.Sprintf("%d", *cpu.Quota)); err != nil {
+			if err := clxc.setConfigItem("lxc.cgroup2.cpu.cfs_quota_us", fmt.Sprintf("%d", *cpu.Quota)); err != nil {
 				return err
 			}
 		}
 			if cpu.Period != nil && *cpu.Period != 0 {
-				if err := clxc.SetConfigItem("lxc.cgroup2.cpu.cfs_period_us", fmt.Sprintf("%d", *cpu.Period)); err != nil {
+				if err := clxc.setConfigItem("lxc.cgroup2.cpu.cfs_period_us", fmt.Sprintf("%d", *cpu.Period)); err != nil {
 					return err
 				}
 			}
 		if cpu.Cpus != "" {
-			if err := clxc.SetConfigItem("lxc.cgroup2.cpuset.cpus", cpu.Cpus); err != nil {
+			if err := clxc.setConfigItem("lxc.cgroup2.cpuset.cpus", cpu.Cpus); err != nil {
 				return err
 			}
 		}
 		if cpu.RealtimePeriod != nil && *cpu.RealtimePeriod > 0 {
-			if err := clxc.SetConfigItem("lxc.cgroup2.cpu.rt_period_us", fmt.Sprintf("%d", *cpu.RealtimePeriod)); err != nil {
+			if err := clxc.setConfigItem("lxc.cgroup2.cpu.rt_period_us", fmt.Sprintf("%d", *cpu.RealtimePeriod)); err != nil {
 				return err
 			}
 		}
 		if cpu.RealtimeRuntime != nil && *cpu.RealtimeRuntime > 0 {
-			if err := clxc.SetConfigItem("lxc.cgroup2.cpu.rt_runtime_us", fmt.Sprintf("%d", *cpu.RealtimeRuntime)); err != nil {
+			if err := clxc.setConfigItem("lxc.cgroup2.cpu.rt_runtime_us", fmt.Sprintf("%d", *cpu.RealtimeRuntime)); err != nil {
 				return err
 			}
 		}

--- a/container.go
+++ b/container.go
@@ -155,7 +155,7 @@ func (c *Container) isMonitorRunning() bool {
 	}
 
 	// if WNOHANG was specified and one or more child(ren) specified by pid exist,
-	// but have not yet changed state, then 0 is returned
+	// but have not yet exited, then 0 is returned
 	if pid == 0 {
 		return true
 	}
@@ -209,7 +209,7 @@ func (c *Container) waitStarted(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			if !c.isMonitorRunning() {
-				return fmt.Errorf("monitor already died")
+				return nil
 			}
 			initState, _ := c.getContainerInitState()
 			if initState != specs.StateCreated {

--- a/container.go
+++ b/container.go
@@ -312,9 +312,9 @@ func (c *Container) kill(ctx context.Context, signum unix.Signal) error {
 	return nil
 }
 
-// GetConfigItem is a wrapper function and returns the
-// first value returned by  *lxc.Container.ConfigItem
-func (c *Container) GetConfigItem(key string) string {
+// getConfigItem is a wrapper function and returns the
+// first value returned by lxc.Container.ConfigItem
+func (c *Container) getConfigItem(key string) string {
 	vals := c.LinuxContainer.ConfigItem(key)
 	if len(vals) > 0 {
 		first := vals[0]
@@ -327,9 +327,9 @@ func (c *Container) GetConfigItem(key string) string {
 	return ""
 }
 
-// SetConfigItem is a wrapper for *lxc.Container.SetConfigItem.
+// setConfigItem is a wrapper for lxc.Container.setConfigItem.
 // and only adds additional logging.
-func (c *Container) SetConfigItem(key, value string) error {
+func (c *Container) setConfigItem(key, value string) error {
 	err := c.LinuxContainer.SetConfigItem(key, value)
 	if err != nil {
 		return fmt.Errorf("failed to set config item '%s=%s': %w", key, value, err)
@@ -338,8 +338,8 @@ func (c *Container) SetConfigItem(key, value string) error {
 	return nil
 }
 
-// SupportsConfigItem is a wrapper for *lxc.Container.IsSupportedConfig item.
-func (c *Container) SupportsConfigItem(keys ...string) bool {
+// supportsConfigItem is a wrapper for lxc.Container.IsSupportedConfig item.
+func (c *Container) supportsConfigItem(keys ...string) bool {
 	canCheck := lxc.VersionAtLeast(4, 0, 6)
 	if !canCheck {
 		c.Log.Warn().Msg("lxc.IsSupportedConfigItem is broken in liblxc < 4.0.6")

--- a/container.go
+++ b/container.go
@@ -31,17 +31,21 @@ type ContainerConfig struct {
 	// The ContainerID should match the following pattern `[a-z][a-z0-9-_]+`
 	ContainerID string
 
-	BundlePath    string
+	// BundlePath is the OCI bundle path.
+	BundlePath string
+
 	ConsoleSocket string `json:",omitempty"`
 
-	// PidFile is the absolute PID file path
-	// for the container monitor process (ExecStart)
+	// MonitorCgroupDir is the cgroup directory path
+	// for the liblxc monitor process `lxcri-start`
+	// relative to the cgroup root.
 	MonitorCgroupDir string
 
 	CgroupDir string
 
 	// LogFile is the liblxc log file path
 	LogFile string
+
 	// LogLevel is the liblxc log level
 	LogLevel string
 
@@ -59,7 +63,7 @@ func (c Container) syncFifoPath() string {
 }
 
 // RuntimePath returns the absolute path to the given sub path
-// within the container root.
+// within the container runtime directory.
 func (c Container) RuntimePath(subPath ...string) string {
 	return filepath.Join(c.runtimeDir, filepath.Join(subPath...))
 }

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -22,41 +22,24 @@ The runtime evaluates the flag value in the following order (lower order takes p
 ### Environment variables
 
 Currently you have to compile to environment file yourself.</br>
-To list  all available variables:
+
+All environment variables are listed in the cmline help `lxcri --help`
+
+To compile a list of all available variables:
 
 ```
-grep EnvVars cmd/cli.go | grep -o LXCRI_[A-Za-z_]* | xargs -n1 -I'{}' echo "#{}="
+grep EnvVars cmd/lxcri/* | grep -o LXCRI_[A-Za-z_]* | xargs -I'{}' echo "#{}="
 ```
 
 ###  Environment file
 
 The default path to the environment file is `/etc/defaults/lxcri`.</br>
-It is loaded on every start of the `lxcri` binary, so changes take immediate effect.</br>
+It is loaded on every start of the `lxcri` binary, so changes take immediate effect
+for the next `lxcri` process started by `cri-o`.</br>
 Empty lines and those commented with a leading *#* are ignored.</br>
 
 A malformed environment will let the next runtime call fail.</br>
 In production it's recommended that you replace the environment file atomically.</br>
-
-E.g the environment file `/etc/default/lxcri` could look like this:
-
-```sh
-LXCRI_LOG_LEVEL=debug
-LXCRI_CONTAINER_LOG_LEVEL=debug
-#LXCRI_LOG_FILE=
-#LXCRI_LOG_TIMESTAMP=
-#LXCRI_MONITOR_CGROUP=
-#LXCRI_LIBEXEC=
-#LXCRI_APPARMOR=
-#LXCRI_CAPABILITIES=
-#LXCRI_CGROUP_DEVICES=
-#LXCRI_SECCOMP=
-#LXCRI_CREATE_TIMEOUT=
-#LXCRI_CREATE_HOOK=/usr/local/bin/lxcri-backup.sh
-#LXCRI_CREATE_HOOK_TIMEOUT=
-#LXCRI_START_TIMEOUT=
-#LXCRI_KILL_TIMEOUT=
-#LXCRI_DELETE_TIMEOUT=
-```
 
 ### Runtime (security) features
 

--- a/init.go
+++ b/init.go
@@ -43,7 +43,7 @@ func configureInit(rt *Runtime, c *Container) error {
 		Options:     []string{"bind", "ro", "nodev", "nosuid", "create=dir"},
 	})
 
-	if err := c.SetConfigItem("lxc.init.cwd", initDir); err != nil {
+	if err := c.setConfigItem("lxc.init.cwd", initDir); err != nil {
 		return err
 	}
 
@@ -74,7 +74,7 @@ func configureInit(rt *Runtime, c *Container) error {
 		Type:        "bind",
 		Options:     []string{"bind", "ro", "nosuid"},
 	})
-	return c.SetConfigItem("lxc.init.cmd", initCmd)
+	return c.setConfigItem("lxc.init.cmd", initCmd)
 }
 
 func touchFile(filePath string, perm os.FileMode) error {
@@ -90,25 +90,25 @@ func configureInitUser(c *Container) error {
 	// TODO ensure that the user namespace is enabled
 	// See `man lxc.container.conf` lxc.idmap.
 	for _, m := range c.Spec.Linux.UIDMappings {
-		if err := c.SetConfigItem("lxc.idmap", fmt.Sprintf("u %d %d %d", m.ContainerID, m.HostID, m.Size)); err != nil {
+		if err := c.setConfigItem("lxc.idmap", fmt.Sprintf("u %d %d %d", m.ContainerID, m.HostID, m.Size)); err != nil {
 			return err
 		}
 	}
 
 	for _, m := range c.Spec.Linux.GIDMappings {
-		if err := c.SetConfigItem("lxc.idmap", fmt.Sprintf("g %d %d %d", m.ContainerID, m.HostID, m.Size)); err != nil {
+		if err := c.setConfigItem("lxc.idmap", fmt.Sprintf("g %d %d %d", m.ContainerID, m.HostID, m.Size)); err != nil {
 			return err
 		}
 	}
 
-	if err := c.SetConfigItem("lxc.init.uid", fmt.Sprintf("%d", c.Spec.Process.User.UID)); err != nil {
+	if err := c.setConfigItem("lxc.init.uid", fmt.Sprintf("%d", c.Spec.Process.User.UID)); err != nil {
 		return err
 	}
-	if err := c.SetConfigItem("lxc.init.gid", fmt.Sprintf("%d", c.Spec.Process.User.GID)); err != nil {
+	if err := c.setConfigItem("lxc.init.gid", fmt.Sprintf("%d", c.Spec.Process.User.GID)); err != nil {
 		return err
 	}
 
-	if len(c.Spec.Process.User.AdditionalGids) > 0 && c.SupportsConfigItem("lxc.init.groups") {
+	if len(c.Spec.Process.User.AdditionalGids) > 0 && c.supportsConfigItem("lxc.init.groups") {
 		var b strings.Builder
 		for i, gid := range c.Spec.Process.User.AdditionalGids {
 			if i > 0 {
@@ -116,7 +116,7 @@ func configureInitUser(c *Container) error {
 			}
 			fmt.Fprintf(&b, "%d", gid)
 		}
-		if err := c.SetConfigItem("lxc.init.groups", b.String()); err != nil {
+		if err := c.setConfigItem("lxc.init.groups", b.String()); err != nil {
 			return err
 		}
 	}

--- a/install.sh
+++ b/install.sh
@@ -26,15 +26,16 @@ case "$DISTRIBUTION" in
 	PKGS="$PKGS $PKGS_RUNTIME"
 	;;
 "arch")
+	# NOTE official archlinux images are really large
+	# archlinux:latest unpacked image size is > 400MB (vs ubuntu:latest ~ 75MB)
 	INSTALL_PKGS=pacman_install
 	CLEAN_PKGS=pacman_clean
 
-	BUILD_PKGS=""
-	BUILD_PKGS="$PKGS_PKGS "
+	PKGS_BUILD="base-devel wget git libtool m4 automake autoconf"
 
-	PKGS_RUNTIME=""
-	PKGS=""
-	PKGS="$PKGS "
+	PKGS_RUNTIME="libseccomp apparmor btrfs-progs device-mapper libcap"
+	PKGS="conntrack-tools ethtool iproute2 ebtables iptables-nft socat"
+	PKGS="$PKGS ca-certificates glib2 systemd tzdata"
 	PKGS="$PKGS $PKGS_RUNTIME"
 	;;
 "alpine")
@@ -48,8 +49,6 @@ case "$DISTRIBUTION" in
 	PKGS="conntrack-tools ebtables ethtool iproute2 iptables ip6tables socat"
 	PKGS="$PKGS ca-certificates glib runit tzdata"
 	PKGS="$PKGS $PKGS_RUNTIME"
-
-	export MUSL_CC="cc"
 	;;
 *)
 	echo "unsupported distribution '$DISTRIBUTION'"
@@ -84,13 +83,16 @@ apt_clean() {
 }
 
 pacman_install() {
-	echo "not implemented"
-	exit 1
+	pacman -Sy
+	# NOTE: the option '--ask 4' is undocumented but the only way to let pacman
+	# resolve conflicts (e.g iptables and iptables-nft)
+	# see https://unix.stackexchange.com/questions/274727/how-to-force-pacman-to-answer-yes-to-all-questions
+	pacman -S --noconfirm --needed $@ --ask 4
 }
 
 pacman_clean() {
-	echo "not implemented"
-	exit 1
+	pacman -R -ss --unneeded --noconfirm $@
+	pacman -Scc
 }
 
 apk_install() {

--- a/mount.go
+++ b/mount.go
@@ -44,7 +44,7 @@ func filterMountOptions(rt *Runtime, fs string, opts []string) []string {
 
 func configureMounts(rt *Runtime, c *Container) error {
 	// excplicitly disable auto-mounting
-	if err := c.SetConfigItem("lxc.mount.auto", ""); err != nil {
+	if err := c.setConfigItem("lxc.mount.auto", ""); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func configureMounts(rt *Runtime, c *Container) error {
 
 		mnt := fmt.Sprintf("%s %s %s %s", ms.Source, ms.Destination, ms.Type, strings.Join(ms.Options, ","))
 
-		if err := c.SetConfigItem("lxc.mount.entry", mnt); err != nil {
+		if err := c.setConfigItem("lxc.mount.entry", mnt); err != nil {
 			return err
 		}
 	}

--- a/namespaces.go
+++ b/namespaces.go
@@ -73,12 +73,12 @@ func configureNamespaces(c *Container) error {
 		}
 
 		configKey := fmt.Sprintf("lxc.namespace.share.%s", n.Name)
-		if err := c.SetConfigItem(configKey, ns.Path); err != nil {
+		if err := c.setConfigItem(configKey, ns.Path); err != nil {
 			return err
 		}
 	}
 
-	return c.SetConfigItem("lxc.namespace.clone", strings.Join(cloneNamespaces, " "))
+	return c.setConfigItem("lxc.namespace.clone", strings.Join(cloneNamespaces, " "))
 }
 
 func isNamespaceEnabled(spec *specs.Spec, nsType specs.LinuxNamespaceType) bool {

--- a/runtime.go
+++ b/runtime.go
@@ -58,19 +58,24 @@ type RuntimeFeatures struct {
 type Runtime struct {
 	// Log is the logger used by the runtime.
 	Log zerolog.Logger `json:"-"`
+
 	// Root is the file path to the runtime directory.
 	// Directories for containers created by the runtime
 	// are created within this directory.
 	Root string
+
 	// Use systemd encoded cgroup path (from crio-o/conmon)
 	// is true if /etc/crio/crio.conf#cgroup_manager = "systemd"
 	SystemdCgroup bool
+
 	// Path for lxc monitor cgroup (lxc specific feature).
 	// This is the cgroup where the liblxc monitor process (lxcri-start)
 	// will be placed in. It's similar to /etc/crio/crio.conf#conmon_cgroup
 	MonitorCgroup string
+
 	// LibexecDir is the the directory that contains the runtime executables.
 	LibexecDir string
+
 	// Featuress are runtime (security) features that apply to all containers
 	// created by the runtime.
 	Features RuntimeFeatures
@@ -219,8 +224,8 @@ func (rt *Runtime) Load(containerID string) (*Container, error) {
 }
 
 // Start starts the given container.
-// Start simply unblocks the container init process `lxcri-init`,
-// which then executes the actuall container process.
+// Start simply unblocks the init process `lxcri-init`,
+// which then executes the container process.
 // The given container must have been created with Runtime.Create.
 func (rt *Runtime) Start(ctx context.Context, c *Container) error {
 	rt.Log.Info().Msg("notify init to start container process")

--- a/runtime.go
+++ b/runtime.go
@@ -262,7 +262,7 @@ func (rt *Runtime) runStartCmd(ctx context.Context, c *Container) (err error) {
 	if c.ConsoleSocket == "" && !c.Spec.Process.Terminal {
 		// Inherit stdio from calling process (conmon).
 		// lxc.console.path must be set to 'none' or stdio of init process is replaced with a PTY by lxc
-		if err := c.SetConfigItem("lxc.console.path", "none"); err != nil {
+		if err := c.setConfigItem("lxc.console.path", "none"); err != nil {
 			return err
 		}
 		cmd.Stdin = os.Stdin
@@ -270,7 +270,7 @@ func (rt *Runtime) runStartCmd(ctx context.Context, c *Container) (err error) {
 		cmd.Stderr = os.Stderr
 	}
 
-	// NOTE any config change via clxc.SetConfigItem
+	// NOTE any config change via clxc.setConfigItem
 	// must be done before calling SaveConfigFile
 	err = c.LinuxContainer.SaveConfigFile(c.ConfigFilePath())
 	if err != nil {


### PR DESCRIPTION
* Fix race in `lxcri start`
* Make go-lxc config item wrapper functions private
* Upgrade container image