### PR TITLE
Add support for structured config file and `lxcri config` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PKG_CONFIG_PATH ?= $(PREFIX)/lib/pkgconfig
 # Note: The default pkg-config directory is search after PKG_CONFIG_PATH
 # Note: (Exported) environment variables are NOT visible in the environment of the $(shell ...) function.
 export PKG_CONFIG_PATH
-LDFLAGS=-X main.version=$(COMMIT) -X main.libexecDir=$(LIBEXEC_DIR)
+LDFLAGS=-X main.version=$(COMMIT) -X main.defaultLibexecDir=$(LIBEXEC_DIR)
 CC ?= cc
 SHELL_SCRIPTS = $(shell find . -name \*.sh)
 GO_SRC = $(shell find . -name \*.go | grep -v _test.go)

--- a/cgroup.go
+++ b/cgroup.go
@@ -116,7 +116,7 @@ func configureCgroup(rt *Runtime, c *Container) error {
 }
 
 func configureCgroupPath(rt *Runtime, c *Container) error {
-	if rt.SystemdCgroup {
+	if c.SystemdCgroup {
 		c.CgroupDir = parseSystemdCgroupPath(c.Spec.Linux.CgroupsPath)
 	} else {
 		c.CgroupDir = c.Spec.Linux.CgroupsPath

--- a/cmd/lxcri/cli.go
+++ b/cmd/lxcri/cli.go
@@ -70,7 +70,7 @@ var defaultApp = app{
 		LogFile:           "/var/log/lxcri/lxcri.log",
 		LogLevel:          "info",
 		ContainerLogFile:  "/var/log/lxcri/lxcri.log",
-		ContainerLogLevel: "info",
+		ContainerLogLevel: "warn",
 	},
 
 	Timeouts: timeouts{

--- a/cmd/lxcri/cli.go
+++ b/cmd/lxcri/cli.go
@@ -18,9 +18,6 @@ import (
 )
 
 var (
-	// Environment variables are populated by default from this environment file.
-	// Existing environment variables are preserved.
-	envFile        = "/etc/default/lxcri"
 	defaultLogFile = "/var/log/lxcri/lxcri.log"
 	version        = "undefined"
 	libexecDir     = "/usr/libexec/lxcri"
@@ -212,24 +209,6 @@ func main() {
 	}
 
 	startTime := time.Now()
-
-	// Environment variables must be injected from file before app.Run() is called.
-	// Otherwise the values are not set to the crioLXC instance.
-	// FIXME when calling '--help' defaults are overwritten with environment variables.
-	// So you will never see the real default value if either an environment file is present
-	// or an environment variable is set.
-	env, err := loadEnvFile(envFile)
-	if err != nil {
-		println(err.Error())
-		os.Exit(1)
-	}
-	for key, val := range env {
-		if err := setEnv(key, val, false); err != nil {
-			err = fmt.Errorf("failed to set environment variable \"%s=%s\": %w", key, val, err)
-			println(err.Error())
-			os.Exit(1)
-		}
-	}
 
 	app.CommandNotFound = func(ctx *cli.Context, cmd string) {
 		fmt.Fprintf(os.Stderr, "undefined subcommand %q cmdline%s\n", cmd, os.Args)

--- a/cmd/lxcri/cli.go
+++ b/cmd/lxcri/cli.go
@@ -273,6 +273,34 @@ func main() {
 			Value:       clxc.Features.Seccomp,
 			Destination: &clxc.Features.Seccomp,
 		},
+		&cli.UintFlag{
+			Name:        "create-timeout",
+			Usage:       "maximum duration in seconds for create to complete",
+			EnvVars:     []string{"LXCRI_CREATE_TIMEOUT"},
+			Value:       clxc.Timeouts.CreateTimeout,
+			Destination: &clxc.Timeouts.CreateTimeout,
+		},
+		&cli.UintFlag{
+			Name:        "start-timeout",
+			Usage:       "maximum duration in seconds for start to complete",
+			EnvVars:     []string{"LXCRI_START_TIMEOUT"},
+			Value:       clxc.Timeouts.StartTimeout,
+			Destination: &clxc.Timeouts.StartTimeout,
+		},
+		&cli.UintFlag{
+			Name:        "kill-timeout",
+			Usage:       "timeout for killing all processes in container cgroup",
+			EnvVars:     []string{"LXCRI_KILL_TIMEOUT"},
+			Value:       clxc.Timeouts.KillTimeout,
+			Destination: &clxc.Timeouts.KillTimeout,
+		},
+		&cli.UintFlag{
+			Name:        "delete-timeout",
+			Usage:       "maximum duration in seconds for delete to complete",
+			EnvVars:     []string{"LXCRI_DELETE_TIMEOUT"},
+			Value:       clxc.Timeouts.DeleteTimeout,
+			Destination: &clxc.Timeouts.DeleteTimeout,
+		},
 	}
 
 	startTime := time.Now()

--- a/cmd/lxcri/utils.go
+++ b/cmd/lxcri/utils.go
@@ -10,48 +10,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func setEnv(key, val string, overwrite bool) error {
-	_, exist := os.LookupEnv(key)
-	if !exist || overwrite {
-		return os.Setenv(key, val)
-	}
-	return nil
-}
-
-func loadEnvFile(envFile string) (map[string]string, error) {
-	// don't fail if environment file does not exist
-	_, err := os.Stat(envFile)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	// #nosec
-	data, err := os.ReadFile(envFile)
-	if err != nil {
-		return nil, err
-	}
-	lines := strings.Split(string(data), "\n")
-	env := make(map[string]string, len(lines))
-	for n, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		// skip over comments and blank lines
-		if len(trimmed) == 0 || trimmed[0] == '#' {
-			continue
-		}
-		vals := strings.SplitN(trimmed, "=", 2)
-		if len(vals) != 2 {
-			return nil, fmt.Errorf("invalid environment variable at line %s:%d", envFile, n+1)
-		}
-		key := strings.TrimSpace(vals[0])
-		val := strings.Trim(strings.TrimSpace(vals[1]), `"'`)
-		env[key] = val
-	}
-	return env, nil
-}
-
 func parseSignal(sig string) unix.Signal {
 	if sig == "" {
 		return unix.SIGTERM

--- a/container.go
+++ b/container.go
@@ -43,6 +43,10 @@ type ContainerConfig struct {
 
 	CgroupDir string
 
+	// Use systemd encoded cgroup path (from crio-o/conmon)
+	// is true if /etc/crio/crio.conf#cgroup_manager = "systemd"
+	SystemdCgroup bool
+
 	// LogFile is the liblxc log file path
 	LogFile string
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -6,40 +6,27 @@
 * `bundle config` the lxcri container state (bundle path, pidfile ....)
 * `runtime spec` the OCI runtime spec from the bundle
 
-## Setup 
+## Configuration
 
 The runtime binary implements flags that are required by the `OCI runtime spec`,</br>
 and flags that are runtime specific (timeouts, hooks, logging ...).
 
+The configuration file path defaults to **/etc/lxcri/lxcri.yaml**
+and can changed with the **LXCRI_CONFIG** environment variable.
 Most of the runtime specific flags have corresponding environment variables. See `lxcri --help`.</br>
-The runtime evaluates the flag value in the following order (lower order takes precedence).
+The `lxcri` cli command valuates the configuration in the following order (higher order takes precedence).
 
-1. cmdline flag from process arguments (overwrites process environment)
-2. process environment variable (overwrites environment file)
-3. environment file (overwrites cmdline flag default)
-4. cmdline flag default
+1. builtin default configuration
+2. configuration file
+3. environment variables
+4. commandline flags
 
-### Environment variables
+The `lxcri config` command can be used to display and update the configuration. e.g:
 
-Currently you have to compile to environment file yourself.</br>
-
-All environment variables are listed in the cmline help `lxcri --help`
-
-To compile a list of all available variables:
-
-```
-grep EnvVars cmd/lxcri/* | grep -o LXCRI_[A-Za-z_]* | xargs -I'{}' echo "#{}="
-```
-
-###  Environment file
-
-The default path to the environment file is `/etc/defaults/lxcri`.</br>
-It is loaded on every start of the `lxcri` binary, so changes take immediate effect
-for the next `lxcri` process started by `cri-o`.</br>
-Empty lines and those commented with a leading *#* are ignored.</br>
-
-A malformed environment will let the next runtime call fail.</br>
-In production it's recommended that you replace the environment file atomically.</br>
+* `lxcri config` print active configuration (builtin default configuration merged with config file)
+* `lxcri config --default` shows builtin default configuration
+* `lxcri --log-level debug config` print modified configuration
+* `lxcri --log-level debug config --update-current` update/create modified configuration
 
 ### Runtime (security) features
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/lxc/lxcri
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/creack/pty v1.1.11
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/drachenfels-de/gocapability v0.0.0-20210413092208-755d79b01352
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
@@ -13,6 +12,7 @@ require (
 	golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/lxc/go-lxc.v2 v2.0.0-20210205143421-c4b883be4881
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad

--- a/go.sum
+++ b/go.sum
@@ -51,5 +51,9 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/lxc/go-lxc.v2 v2.0.0-20210205143421-c4b883be4881 h1:YcCjv1g/OoEJ93hK3p+5MhPyuIMD9FwOYF5f4D7rNKk=
 gopkg.in/lxc/go-lxc.v2 v2.0.0-20210205143421-c4b883be4881/go.mod h1:4K0lbUXeslpmjwJZyW1lI6s5j97mrsj4+kpYwwvuLXo=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/runtime.go
+++ b/runtime.go
@@ -64,10 +64,6 @@ type Runtime struct {
 	// are created within this directory.
 	Root string
 
-	// Use systemd encoded cgroup path (from crio-o/conmon)
-	// is true if /etc/crio/crio.conf#cgroup_manager = "systemd"
-	SystemdCgroup bool
-
 	// Path for lxc monitor cgroup (lxc specific feature).
 	// This is the cgroup where the liblxc monitor process (lxcri-start)
 	// will be placed in. It's similar to /etc/crio/crio.conf#conmon_cgroup

--- a/runtime.go
+++ b/runtime.go
@@ -62,15 +62,15 @@ type Runtime struct {
 	// Root is the file path to the runtime directory.
 	// Directories for containers created by the runtime
 	// are created within this directory.
-	Root string
+	Root string `json:",omitempty"`
 
 	// Path for lxc monitor cgroup (lxc specific feature).
 	// This is the cgroup where the liblxc monitor process (lxcri-start)
 	// will be placed in. It's similar to /etc/crio/crio.conf#conmon_cgroup
-	MonitorCgroup string
+	MonitorCgroup string `json:",omitempty"`
 
 	// LibexecDir is the the directory that contains the runtime executables.
-	LibexecDir string
+	LibexecDir string `json:",omitempty"`
 
 	// Featuress are runtime (security) features that apply to all containers
 	// created by the runtime.
@@ -81,7 +81,7 @@ type Runtime struct {
 
 	caps capability.Capabilities
 
-	specs.Hooks
+	specs.Hooks `json:",omitempty"`
 }
 
 func (rt *Runtime) libexec(name string) string {


### PR DESCRIPTION
This implements #25

Support for the environment file `/etc/default/lxcri` was removed in 
favour of a structured config file `/etc/lxcri/lxcri.yaml`.

The new `lxcri config` command can be used to display and modify the configuration. 

New dependencies:

* sigs.k8s.io/yaml v1.2.0