### PR TITLE
matched timeNamespace declaration and assignment

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -24,7 +24,7 @@ var (
 	mountNamespace   = namespace{"mnt", unix.CLONE_NEWNS}
 	networkNamespace = namespace{"net", unix.CLONE_NEWNET}
 	pidNamespace     = namespace{"pid", unix.CLONE_NEWPID}
-	timeNamespace    = namespace{"time", unix.CLONE_NEWTIME}
+	//timeNamespace    = namespace{"time", unix.CLONE_NEWTIME}
 	userNamespace    = namespace{"user", unix.CLONE_NEWUSER}
 	utsNamespace     = namespace{"uts", unix.CLONE_NEWUTS}
 


### PR DESCRIPTION
both should have been commented out in issue #50 implementation, addresses issue #67

workaround for staticcheck build error cased by issue #50 implementation, namespaces.go:27:2: var timeNamespace is unused (U1000)